### PR TITLE
Remove child elements in onUnload

### DIFF
--- a/src/main/java/com/tractionsoftware/gwt/user/client/ui/GroupedListBox.java
+++ b/src/main/java/com/tractionsoftware/gwt/user/client/ui/GroupedListBox.java
@@ -317,6 +317,8 @@ public class GroupedListBox extends SingleListBox {
     @Override
     protected void onUnload() {
         super.onUnload();
+        // Call 'clear' to remove child options/optgroups in an orderly fashion
+        clear();
         groups.clear();
     }
 


### PR DESCRIPTION
The onUnload handler in GroupedListBox was clearing the list of groups, but was not performing the same removal of child elements as is done in the 'clear' method. This could result in 'phantom' elements existing.
Call 'clear' within onUnload in order to replicate its handling. This method creates a new FakeOptGroup at the end of its processing, so onUnload's call to groups.clear() is retained in order to preserve existing behavior, though I'm not sure it matters here.